### PR TITLE
Feat/de 1232 fixes

### DIFF
--- a/src/app/components/table/data.ts
+++ b/src/app/components/table/data.ts
@@ -837,7 +837,7 @@ export const TABLE_VARIATION_5_DATA: {
 
 export const TABLE_VARIATION_6_COLUMNS: ColumnDefinition[] = [
   {
-    title: "Location",
+    title: "Geography",
     field: "name",
     width: "80%",
     formatter: cellBGColorFormatter,

--- a/src/app/pages/datasets/access-to-funding/index.tsx
+++ b/src/app/pages/datasets/access-to-funding/index.tsx
@@ -203,6 +203,7 @@ export const AccessToFundingPage: React.FC = () => {
   const handleResetFilters = () => {
     appliedFiltersActions.setAll({
       ...appliedFiltersData,
+      cycles: [],
       locations: [],
       components: [],
     });
@@ -379,10 +380,16 @@ export const AccessToFundingPage: React.FC = () => {
   const filterString = React.useMemo(() => {
     let filterString = "";
     if (appliedFiltersData.locations.length > 0) {
-      filterString += `geographies=${encodeURIComponent(appliedFiltersData.locations.join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        appliedFiltersData.locations.join(",")
+      )}`;
     }
     if (appliedFiltersData.components.length > 0) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(appliedFiltersData.components.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        appliedFiltersData.components.join(",")
+      )}`;
     }
     return filterString;
   }, [appliedFiltersData]);
@@ -393,19 +400,38 @@ export const AccessToFundingPage: React.FC = () => {
       [...appliedFiltersData.locations, ...chart1AppliedFiltersData.locations]
         .length > 0
     ) {
-      filterString += `geographies=${encodeURIComponent(uniq([...appliedFiltersData.locations, ...chart1AppliedFiltersData.locations]).join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.locations,
+          ...chart1AppliedFiltersData.locations,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.components, ...chart1AppliedFiltersData.components]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(uniq([...appliedFiltersData.components, ...chart1AppliedFiltersData.components]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.components,
+          ...chart1AppliedFiltersData.components,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.cycles, ...chart1AppliedFiltersData.cycles]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}cycles=${encodeURIComponent(uniq([...appliedFiltersData.cycles, ...chart1AppliedFiltersData.cycles]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }cycles=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.cycles,
+          ...chart1AppliedFiltersData.cycles,
+        ]).join(",")
+      )}`;
     }
     return filterString;
   }, [appliedFiltersData, chart1AppliedFiltersData]);
@@ -416,19 +442,38 @@ export const AccessToFundingPage: React.FC = () => {
       [...appliedFiltersData.locations, ...chart2AppliedFiltersData.locations]
         .length > 0
     ) {
-      filterString += `geographies=${encodeURIComponent(uniq([...appliedFiltersData.locations, ...chart2AppliedFiltersData.locations]).join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.locations,
+          ...chart2AppliedFiltersData.locations,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.components, ...chart2AppliedFiltersData.components]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(uniq([...appliedFiltersData.components, ...chart2AppliedFiltersData.components]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.components,
+          ...chart2AppliedFiltersData.components,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.cycles, ...chart2AppliedFiltersData.cycles]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}cycles=${encodeURIComponent(uniq([...appliedFiltersData.cycles, ...chart2AppliedFiltersData.cycles]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }cycles=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.cycles,
+          ...chart2AppliedFiltersData.cycles,
+        ]).join(",")
+      )}`;
     }
     return filterString;
   }, [appliedFiltersData, chart2AppliedFiltersData]);
@@ -439,19 +484,38 @@ export const AccessToFundingPage: React.FC = () => {
       [...appliedFiltersData.locations, ...chart3AppliedFiltersData.locations]
         .length > 0
     ) {
-      filterString += `geographies=${encodeURIComponent(uniq([...appliedFiltersData.locations, ...chart3AppliedFiltersData.locations]).join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.locations,
+          ...chart3AppliedFiltersData.locations,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.components, ...chart3AppliedFiltersData.components]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(uniq([...appliedFiltersData.components, ...chart3AppliedFiltersData.components]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.components,
+          ...chart3AppliedFiltersData.components,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.cycles, ...chart3AppliedFiltersData.cycles]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}periods=${encodeURIComponent(uniq([...appliedFiltersData.cycles.map((c) => c.split("-")[0]), ...chart3AppliedFiltersData.cycles.map((c) => c.split("-")[0])]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }periods=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.cycles.map((c) => c.split("-")[0]),
+          ...chart3AppliedFiltersData.cycles.map((c) => c.split("-")[0]),
+        ]).join(",")
+      )}`;
     }
     return filterString;
   }, [appliedFiltersData, chart3AppliedFiltersData]);
@@ -514,7 +578,7 @@ export const AccessToFundingPage: React.FC = () => {
   return (
     <DatasetPage
       title="Access to Funding"
-      subtitle="Lorem ipsum."
+      subtitle=""
       filterGroups={filterGroups}
       appliedFilters={pageAppliedFilters}
       handleResetFilters={handleResetFilters}

--- a/src/app/pages/datasets/common/chart-block/index.tsx
+++ b/src/app/pages/datasets/common/chart-block/index.tsx
@@ -176,7 +176,7 @@ export const DatasetChartBlock: React.FC<DatasetChartBlockProps> = (
         }}
       >
         <Box
-          id="content"
+          id={id}
           width="100%"
           minHeight="400px"
           padding="0 32px"

--- a/src/app/pages/datasets/common/page/index.tsx
+++ b/src/app/pages/datasets/common/page/index.tsx
@@ -42,7 +42,18 @@ export const DatasetPage: React.FC<DatasetPageProps> = (
   return (
     <Box padding="50px 0">
       <Typography variant="h1">{props.title}</Typography>
-      <Typography variant="h6">{props.subtitle}</Typography>
+      <Typography
+        variant="h6"
+        sx={
+          props.subtitle.length > 0
+            ? {}
+            : {
+                height: "28.8px",
+              }
+        }
+      >
+        {props.subtitle}
+      </Typography>
       <Divider
         sx={{
           left: 0,

--- a/src/app/pages/datasets/grant-implementation/index.tsx
+++ b/src/app/pages/datasets/grant-implementation/index.tsx
@@ -415,6 +415,7 @@ export const GrantImplementationPage: React.FC = () => {
   const handleResetFilters = () => {
     appliedFiltersActions.setAll({
       ...appliedFiltersData,
+      cycles: [],
       components: [],
       locations: [],
       principalRecipients: [],
@@ -995,22 +996,42 @@ export const GrantImplementationPage: React.FC = () => {
   const filterString = React.useMemo(() => {
     let filterString = "";
     if (appliedFiltersData.locations.length > 0) {
-      filterString += `geographies=${encodeURIComponent(appliedFiltersData.locations.join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        appliedFiltersData.locations.join(",")
+      )}`;
     }
     if (appliedFiltersData.components.length > 0) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(appliedFiltersData.components.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        appliedFiltersData.components.join(",")
+      )}`;
     }
     if (appliedFiltersData.principalRecipientTypes.length > 0) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientTypes=${encodeURIComponent(appliedFiltersData.principalRecipientTypes.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientTypes=${encodeURIComponent(
+        appliedFiltersData.principalRecipientTypes.join(",")
+      )}`;
     }
     if (appliedFiltersData.principalRecipientSubTypes.length > 0) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientSubTypes=${encodeURIComponent(appliedFiltersData.principalRecipientSubTypes.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientSubTypes=${encodeURIComponent(
+        appliedFiltersData.principalRecipientSubTypes.join(",")
+      )}`;
     }
     if (appliedFiltersData.principalRecipients.length > 0) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipients=${encodeURIComponent(appliedFiltersData.principalRecipients.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipients=${encodeURIComponent(
+        appliedFiltersData.principalRecipients.join(",")
+      )}`;
     }
     if (appliedFiltersData.status.length > 0) {
-      filterString += `${filterString.length > 0 ? "&" : ""}status=${encodeURIComponent(appliedFiltersData.status.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }status=${encodeURIComponent(appliedFiltersData.status.join(","))}`;
     }
     if (appliedFiltersData.cycles.length > 0) {
       const years = appliedFiltersData.cycles.map(
@@ -1019,7 +1040,11 @@ export const GrantImplementationPage: React.FC = () => {
       const yearsTo = appliedFiltersData.cycles.map(
         (cycle) => cycle.replace(/ /g, "").split("-")[1]
       );
-      filterString += `${filterString.length > 0 ? "&" : ""}years=${encodeURIComponent(years.join(","))}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }years=${encodeURIComponent(
+        years.join(",")
+      )}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
     }
     return filterString;
   }, [appliedFiltersData]);
@@ -1030,13 +1055,25 @@ export const GrantImplementationPage: React.FC = () => {
       [...appliedFiltersData.locations, ...chart1AppliedFiltersData.locations]
         .length > 0
     ) {
-      filterString += `geographies=${encodeURIComponent(uniq([...appliedFiltersData.locations, ...chart1AppliedFiltersData.locations]).join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.locations,
+          ...chart1AppliedFiltersData.locations,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.components, ...chart1AppliedFiltersData.components]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(uniq([...appliedFiltersData.components, ...chart1AppliedFiltersData.components]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.components,
+          ...chart1AppliedFiltersData.components,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1044,7 +1081,14 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart1AppliedFiltersData.principalRecipients,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipients=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipients, ...chart1AppliedFiltersData.principalRecipients]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipients=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipients,
+          ...chart1AppliedFiltersData.principalRecipients,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1052,7 +1096,14 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart1AppliedFiltersData.principalRecipientSubTypes,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientSubTypes=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipientSubTypes, ...chart1AppliedFiltersData.principalRecipientSubTypes]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientSubTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipientSubTypes,
+          ...chart1AppliedFiltersData.principalRecipientSubTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1060,13 +1111,27 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart1AppliedFiltersData.principalRecipientTypes,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientTypes=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipientTypes, ...chart1AppliedFiltersData.principalRecipientTypes]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipientTypes,
+          ...chart1AppliedFiltersData.principalRecipientTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.status, ...chart1AppliedFiltersData.status]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}status=${encodeURIComponent(uniq([...appliedFiltersData.status, ...chart1AppliedFiltersData.status]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }status=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.status,
+          ...chart1AppliedFiltersData.status,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.cycles, ...chart1AppliedFiltersData.cycles]
@@ -1080,7 +1145,11 @@ export const GrantImplementationPage: React.FC = () => {
         ...appliedFiltersData.cycles,
         ...chart1AppliedFiltersData.cycles,
       ]).map((cycle) => cycle.replace(/ /g, "").split("-")[1]);
-      filterString += `${filterString.length > 0 ? "&" : ""}years=${encodeURIComponent(years.join(","))}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }years=${encodeURIComponent(
+        years.join(",")
+      )}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
     }
     return filterString;
   }, [appliedFiltersData, chart1AppliedFiltersData]);
@@ -1091,13 +1160,25 @@ export const GrantImplementationPage: React.FC = () => {
       [...appliedFiltersData.locations, ...chart2AppliedFiltersData.locations]
         .length > 0
     ) {
-      filterString += `geographies=${encodeURIComponent(uniq([...appliedFiltersData.locations, ...chart2AppliedFiltersData.locations]).join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.locations,
+          ...chart2AppliedFiltersData.locations,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.components, ...chart2AppliedFiltersData.components]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(uniq([...appliedFiltersData.components, ...chart2AppliedFiltersData.components]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.components,
+          ...chart2AppliedFiltersData.components,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1105,7 +1186,14 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart2AppliedFiltersData.principalRecipients,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipients=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipients, ...chart2AppliedFiltersData.principalRecipients]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipients=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipients,
+          ...chart2AppliedFiltersData.principalRecipients,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1113,7 +1201,14 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart2AppliedFiltersData.principalRecipientSubTypes,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientSubTypes=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipientSubTypes, ...chart2AppliedFiltersData.principalRecipientSubTypes]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientSubTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipientSubTypes,
+          ...chart2AppliedFiltersData.principalRecipientSubTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1121,13 +1216,27 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart2AppliedFiltersData.principalRecipientTypes,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientTypes=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipientTypes, ...chart2AppliedFiltersData.principalRecipientTypes]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipientTypes,
+          ...chart2AppliedFiltersData.principalRecipientTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.status, ...chart2AppliedFiltersData.status]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}status=${encodeURIComponent(uniq([...appliedFiltersData.status, ...chart2AppliedFiltersData.status]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }status=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.status,
+          ...chart2AppliedFiltersData.status,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.cycles, ...chart2AppliedFiltersData.cycles]
@@ -1141,7 +1250,11 @@ export const GrantImplementationPage: React.FC = () => {
         ...appliedFiltersData.cycles,
         ...chart2AppliedFiltersData.cycles,
       ]).map((cycle) => cycle.replace(/ /g, "").split("-")[1]);
-      filterString += `${filterString.length > 0 ? "&" : ""}years=${encodeURIComponent(years.join(","))}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }years=${encodeURIComponent(
+        years.join(",")
+      )}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
     }
     return filterString;
   }, [appliedFiltersData, chart2AppliedFiltersData]);
@@ -1152,13 +1265,25 @@ export const GrantImplementationPage: React.FC = () => {
       [...appliedFiltersData.locations, ...chart3AppliedFiltersData.locations]
         .length > 0
     ) {
-      filterString += `geographies=${encodeURIComponent(uniq([...appliedFiltersData.locations, ...chart3AppliedFiltersData.locations]).join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.locations,
+          ...chart3AppliedFiltersData.locations,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.components, ...chart3AppliedFiltersData.components]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(uniq([...appliedFiltersData.components, ...chart3AppliedFiltersData.components]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.components,
+          ...chart3AppliedFiltersData.components,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1166,7 +1291,14 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart3AppliedFiltersData.principalRecipients,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipients=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipients, ...chart3AppliedFiltersData.principalRecipients]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipients=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipients,
+          ...chart3AppliedFiltersData.principalRecipients,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1174,7 +1306,14 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart3AppliedFiltersData.principalRecipientSubTypes,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientSubTypes=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipientSubTypes, ...chart3AppliedFiltersData.principalRecipientSubTypes]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientSubTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipientSubTypes,
+          ...chart3AppliedFiltersData.principalRecipientSubTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1182,13 +1321,27 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart3AppliedFiltersData.principalRecipientTypes,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientTypes=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipientTypes, ...chart3AppliedFiltersData.principalRecipientTypes]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipientTypes,
+          ...chart3AppliedFiltersData.principalRecipientTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.status, ...chart3AppliedFiltersData.status]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}status=${encodeURIComponent(uniq([...appliedFiltersData.status, ...chart3AppliedFiltersData.status]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }status=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.status,
+          ...chart3AppliedFiltersData.status,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.cycles, ...chart3AppliedFiltersData.cycles]
@@ -1202,7 +1355,11 @@ export const GrantImplementationPage: React.FC = () => {
         ...appliedFiltersData.cycles,
         ...chart3AppliedFiltersData.cycles,
       ]).map((cycle) => cycle.replace(/ /g, "").split("-")[1]);
-      filterString += `${filterString.length > 0 ? "&" : ""}years=${encodeURIComponent(years.join(","))}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }years=${encodeURIComponent(
+        years.join(",")
+      )}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
     }
     return filterString;
   }, [appliedFiltersData, chart3AppliedFiltersData]);
@@ -1213,13 +1370,25 @@ export const GrantImplementationPage: React.FC = () => {
       [...appliedFiltersData.locations, ...chart4AppliedFiltersData.locations]
         .length > 0
     ) {
-      filterString += `geographies=${encodeURIComponent(uniq([...appliedFiltersData.locations, ...chart4AppliedFiltersData.locations]).join(","))}`;
+      filterString += `geographies=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.locations,
+          ...chart4AppliedFiltersData.locations,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.components, ...chart4AppliedFiltersData.components]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}components=${encodeURIComponent(uniq([...appliedFiltersData.components, ...chart4AppliedFiltersData.components]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }components=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.components,
+          ...chart4AppliedFiltersData.components,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1227,7 +1396,14 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart4AppliedFiltersData.principalRecipients,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipients=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipients, ...chart4AppliedFiltersData.principalRecipients]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipients=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipients,
+          ...chart4AppliedFiltersData.principalRecipients,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1235,7 +1411,14 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart4AppliedFiltersData.principalRecipientSubTypes,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientSubTypes=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipientSubTypes, ...chart4AppliedFiltersData.principalRecipientSubTypes]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientSubTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipientSubTypes,
+          ...chart4AppliedFiltersData.principalRecipientSubTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -1243,13 +1426,27 @@ export const GrantImplementationPage: React.FC = () => {
         ...chart4AppliedFiltersData.principalRecipientTypes,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}principalRecipientTypes=${encodeURIComponent(uniq([...appliedFiltersData.principalRecipientTypes, ...chart4AppliedFiltersData.principalRecipientTypes]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }principalRecipientTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.principalRecipientTypes,
+          ...chart4AppliedFiltersData.principalRecipientTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.status, ...chart4AppliedFiltersData.status]
         .length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}status=${encodeURIComponent(uniq([...appliedFiltersData.status, ...chart4AppliedFiltersData.status]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }status=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.status,
+          ...chart4AppliedFiltersData.status,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.cycles, ...chart4AppliedFiltersData.cycles]
@@ -1263,7 +1460,11 @@ export const GrantImplementationPage: React.FC = () => {
         ...appliedFiltersData.cycles,
         ...chart4AppliedFiltersData.cycles,
       ]).map((cycle) => cycle.replace(/ /g, "").split("-")[1]);
-      filterString += `${filterString.length > 0 ? "&" : ""}years=${encodeURIComponent(years.join(","))}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }years=${encodeURIComponent(
+        years.join(",")
+      )}&yearsTo=${encodeURIComponent(yearsTo.join(","))}`;
     }
     return filterString;
   }, [appliedFiltersData, chart4AppliedFiltersData]);

--- a/src/app/pages/datasets/resource-mobilization/index.tsx
+++ b/src/app/pages/datasets/resource-mobilization/index.tsx
@@ -278,13 +278,21 @@ export const ResourceMobilizationPage: React.FC = () => {
   const filterString = React.useMemo(() => {
     let filterString = "";
     if (appliedFiltersData.donorTypes.length > 0) {
-      filterString += `donorTypes=${encodeURIComponent(appliedFiltersData.donorTypes.join(","))}`;
+      filterString += `donorTypes=${encodeURIComponent(
+        appliedFiltersData.donorTypes.join(",")
+      )}`;
     }
     if (appliedFiltersData.donors.length > 0) {
-      filterString += `${filterString.length > 0 ? "&" : ""}donors=${encodeURIComponent(appliedFiltersData.donors.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }donors=${encodeURIComponent(appliedFiltersData.donors.join(","))}`;
     }
     if (appliedFiltersData.replenishmentPeriods.length > 0) {
-      filterString += `${filterString.length > 0 ? "&" : ""}periods=${encodeURIComponent(appliedFiltersData.replenishmentPeriods.join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }periods=${encodeURIComponent(
+        appliedFiltersData.replenishmentPeriods.join(",")
+      )}`;
     }
     return filterString;
   }, [appliedFiltersData]);
@@ -295,13 +303,25 @@ export const ResourceMobilizationPage: React.FC = () => {
       [...appliedFiltersData.donorTypes, ...chartAppliedFiltersData.donorTypes]
         .length > 0
     ) {
-      filterString += `donorTypes=${encodeURIComponent(uniq([...appliedFiltersData.donorTypes, ...chartAppliedFiltersData.donorTypes]).join(","))}`;
+      filterString += `donorTypes=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.donorTypes,
+          ...chartAppliedFiltersData.donorTypes,
+        ]).join(",")
+      )}`;
     }
     if (
       [...appliedFiltersData.donors, ...chartAppliedFiltersData.donors].length >
       0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}donors=${encodeURIComponent(uniq([...appliedFiltersData.donors, ...chartAppliedFiltersData.donors]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }donors=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.donors,
+          ...chartAppliedFiltersData.donors,
+        ]).join(",")
+      )}`;
     }
     if (
       [
@@ -309,7 +329,14 @@ export const ResourceMobilizationPage: React.FC = () => {
         ...chartAppliedFiltersData.replenishmentPeriods,
       ].length > 0
     ) {
-      filterString += `${filterString.length > 0 ? "&" : ""}periods=${encodeURIComponent(uniq([...appliedFiltersData.replenishmentPeriods, ...chartAppliedFiltersData.replenishmentPeriods]).join(","))}`;
+      filterString += `${
+        filterString.length > 0 ? "&" : ""
+      }periods=${encodeURIComponent(
+        uniq([
+          ...appliedFiltersData.replenishmentPeriods,
+          ...chartAppliedFiltersData.replenishmentPeriods,
+        ]).join(",")
+      )}`;
     }
     return filterString;
   }, [appliedFiltersData, chartAppliedFiltersData]);
@@ -460,7 +487,7 @@ export const ResourceMobilizationPage: React.FC = () => {
                   <Grid item xs={12} sm={6} md={6} lg={3} key={item.name}>
                     <Box bgcolor="#F1F3F5" padding="5px 10px">
                       <Typography variant="h5">{item.value}</Typography>
-                      <Typography fontSize="12px">from {item.name}</Typography>
+                      <Typography fontSize="12px">{item.name}</Typography>
                     </Box>
                   </Grid>
                 ))}

--- a/src/app/pages/home/index.tsx
+++ b/src/app/pages/home/index.tsx
@@ -327,7 +327,9 @@ export const Home: React.FC = () => {
         filterString = `years=${yearFrom.join(",")}`;
       }
       if (yearTo.length > 0) {
-        filterString += `${filterString.length > 0 ? "&" : ""}yearsTo=${yearTo.join(",")}`;
+        filterString += `${
+          filterString.length > 0 ? "&" : ""
+        }yearsTo=${yearTo.join(",")}`;
       }
     }
     fetchBudgetsTreemap({
@@ -361,7 +363,9 @@ export const Home: React.FC = () => {
         filterString = `years=${yearFrom.join(",")}`;
       }
       if (yearTo.length > 0) {
-        filterString += `${filterString.length > 0 ? "&" : ""}yearsTo=${yearTo.join(",")}`;
+        filterString += `${
+          filterString.length > 0 ? "&" : ""
+        }yearsTo=${yearTo.join(",")}`;
       }
     }
     fetchDisbursementsLineChart({
@@ -395,7 +399,9 @@ export const Home: React.FC = () => {
         filterString = `years=${yearFrom.join(",")}`;
       }
       if (yearTo.length > 0) {
-        filterString += `${filterString.length > 0 ? "&" : ""}yearsTo=${yearTo.join(",")}`;
+        filterString += `${
+          filterString.length > 0 ? "&" : ""
+        }yearsTo=${yearTo.join(",")}`;
       }
     }
     fetchExpendituresHeatmap({
@@ -458,7 +464,9 @@ export const Home: React.FC = () => {
   const allocationsTotal = React.useMemo(() => {
     const total = sumBy(dataAllocationsRadialChart, "value");
     const range = getRange([{ value: total }], ["value"]);
-    return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${range.full}`;
+    return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${
+      range.full
+    }`;
   }, [dataAllocationsRadialChart]);
 
   const disbursementsTotal = React.useMemo(() => {
@@ -467,7 +475,9 @@ export const Home: React.FC = () => {
       total += sumBy(item.data);
     });
     const range = getRange([{ value: total }], ["value"]);
-    return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${range.full}`;
+    return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${
+      range.full
+    }`;
   }, [dataDisbursementsLineChart]);
 
   const totalPledge = React.useMemo(() => {
@@ -489,13 +499,17 @@ export const Home: React.FC = () => {
   const totalBudget = React.useMemo(() => {
     const total = sumBy(dataBudgetsTreemap, "value");
     const range = getRange([{ value: total }], ["value"]);
-    return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${range.full}`;
+    return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${
+      range.full
+    }`;
   }, [dataBudgetsTreemap]);
 
   const expendituresTotal = React.useMemo(() => {
     const total = sumBy(dataExpendituresHeatmap, "value");
     const range = getRange([{ value: total }], ["value"]);
-    return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${range.full}`;
+    return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${
+      range.full
+    }`;
   }, [dataExpendituresHeatmap]);
 
   const fullWidthDivider = (
@@ -529,7 +543,7 @@ export const Home: React.FC = () => {
         showCycleAll
         id="pledges-contributions"
         selectedCycles={chart1Cycles}
-        title={`${totalContribution}`}
+        title={`${totalPledge}`}
         subtitle="Pledges & Contributions"
         loading={loadingPledgesContributionsBarChart}
         empty={dataPledgesContributionsBarChart.length === 0}

--- a/src/app/pages/home/index.tsx
+++ b/src/app/pages/home/index.tsx
@@ -506,6 +506,8 @@ export const Home: React.FC = () => {
 
   const expendituresTotal = React.useMemo(() => {
     const total = sumBy(dataExpendituresHeatmap, "value");
+    console.log("total", total);
+    console.log(dataExpendituresHeatmap, "dataExpendituresHeatmap");
     const range = getRange([{ value: total }], ["value"]);
     return `US$${getFinancialValueWithMetricPrefix(total, range.index, 2)} ${
       range.full

--- a/src/app/pages/location/views/access-to-funding/index.tsx
+++ b/src/app/pages/location/views/access-to-funding/index.tsx
@@ -193,7 +193,9 @@ export const AccessToFunding: React.FC = () => {
   const totalAllocationAmount = React.useMemo(() => {
     const value = sumBy(dataAllocationsRadialChart, "value");
     const range = getRange([{ value }], ["value"]);
-    return `${getFinancialValueWithMetricPrefix(value, range.index, 2)} ${range.full}`;
+    return `${getFinancialValueWithMetricPrefix(value, range.index, 2)} ${
+      range.full
+    }`;
   }, [dataAllocationsRadialChart]);
 
   const raceBarData = React.useMemo(() => {
@@ -373,9 +375,9 @@ export const AccessToFunding: React.FC = () => {
         noSplitText
         id="eligibility"
         title="Eligibility"
-        subtitle="To date"
+        subtitle=""
         empty={!showEligibilityHeatmap}
-        text="Eligibility for funding from the Global Fund is determined by country income classification and disease burden for HIV, tuberculosis and malaria. Below are the components which are eligible for an allocation for the selected allocation period, according to the Global Fund Eligibility Policy.<br/><br/>Eligibility for the 2023-2025 Allocation Period was determined in 2022 and documented in the 2023 Eligibility List. Eligibility does not guarantee a funding allocation. Learn more about Eligibility <a target='_blank' href='https://www.theglobalfund.org/en/applying-for-funding/understand-and-prepare/eligibility/'>here</a> or <a>see the full history of eligibility for this country</a>."
+        text="Eligibility for funding from the Global Fund is determined by country income classification and disease burden for HIV, tuberculosis and malaria. Below are the components which are eligible for an allocation for the selected allocation period, according to the Global Fund Eligibility Policy.<br/><br/>Eligibility for the 2023-2025 Allocation Period was determined in 2022 and documented in the 2023 Eligibility List. Eligibility does not guarantee a funding allocation. Learn more about Eligibility <a target='_blank' href='https://www.theglobalfund.org/en/applying-for-funding/understand-and-prepare/eligibility/'>here</a>."
       >
         <Box height="32px" />
         <Box
@@ -480,9 +482,6 @@ export const AccessToFunding: React.FC = () => {
               </Box>
             </Box>
           </Box>
-          <Tooltip title="">
-            <Info fontSize="small" />
-          </Tooltip>
         </Box>
         <Table
           dataTree


### PR DESCRIPTION
This pr consists of the following tickets: 
- DE-1264 - On the datasets sections, none of the download functions work. 
- DE-1267 - PC Ensure that the large number is the Pledge and not the Contribution
- DE-1279 - For the eligibility table, in the legend, there is a info icon which should be removed
- DE-1280 - In the eligibility section description, replace “Learn more about ...
- DE-1281 - In the eligibility section sub-title, remove “To date”
- DE-1282 - In the documents table, rename the first column header to Geography instead of location
- DE-1299 - In the Number of Donors Mobilized section, remove “from” from all the boxes
- DE-1334 - v3 Review 1 - Datasets - Access to Funding - subtitle adjustment
- DE-1317 - Reset button on the page level filters does nothing